### PR TITLE
feat: add support for full game

### DIFF
--- a/code/web/index.html
+++ b/code/web/index.html
@@ -389,6 +389,20 @@ if (window.matchMedia('(pointer: coarse)').matches) {
     `;
 }
 
+const fullGameMaps = [
+    // 1 through 19. There is also `q3dm0`, but let's skip it.
+    ...(new Array(19).fill(0)).map((_, ind) => `q3dm${ind + 1}`),
+    // 1 through 6
+    ...(new Array(6).fill(0)).map((_, ind) => `q3tourney${ind + 1}`),
+    ...(new Array(4).fill(0)).map((_, ind) => `q3ctf${ind + 1}`),
+];
+/**
+ * @param {Array<any>} arr
+ */
+function randomFromArray(arr) {
+    return arr[Math.floor(Math.random() * arr.length)];
+}
+
 let multiplayer = !!server;
 if (multiplayer) multiplayerMessage.style.display = 'block';
 multiplayerMessage.addEventListener('click', (e) => {
@@ -524,12 +538,12 @@ import(`${buildPath}/ioquake3_opengl2.wasm32.js`).then(async (ioquake3)=>{
                     module.arguments.push(...`
                         +set net_peer_server "${peerServerWebSocket}"
                         +set net_server_name "${server}"
-                        +map q3dm17
+                        +map ${isFullGame ? randomFromArray(fullGameMaps) : 'q3dm17'}
                         `.trim().split(/\s+/));
                 }
             } else {
                 module.arguments.push(...`
-                    +map q3dm17
+                    +map ${isFullGame ? randomFromArray(fullGameMaps) : 'q3dm17'}
                     +addbot sarge ${botSkill}
                     +addbot daemia ${botSkill}
                     +addbot major ${botSkill}

--- a/code/web/index.html
+++ b/code/web/index.html
@@ -339,9 +339,11 @@ window.addEventListener("keydown", (e) => {
         if (!defaultKeyBindingKeyCodes[e.code]) e.preventDefault = () => false;
     }, { capture: true });
 
-let gotDemoq3pak0;
-let demoq3pak0Promise = new Promise((resolve) => {
-    gotDemoq3pak0 = resolve;
+/** @type {(files: Array<[filePath: string, file: Promise<Uint8Array>]>}) => void} */
+let gotPk3Files;
+/** @type {Promise<Array<[filePath: string, file: Promise<Uint8Array>]>}>} */
+let pk3FilesPromise = new Promise((resolve) => {
+    gotPk3Files = resolve;
 });
 
 let username = localStorage.getItem('username');
@@ -503,7 +505,10 @@ import(`${buildPath}/ioquake3_opengl2.wasm32.js`).then(async (ioquake3)=>{
             };
             saveFiles();
             module.FS.mkdirTree('/demoq3');
-            module.FS.writeFile('/demoq3/pak0.pk3', await demoq3pak0Promise);
+            const pk3Files = await pk3FilesPromise;
+            await Promise.all(pk3Files.map(async ([filePath, file]) => {
+                module.FS.writeFile(filePath, await file);
+            }));
             module.FS.writeFile('/demoq3/ztm-flexible-hud.pk3', await ztmFlexibleHud);
             if (multiplayer) {
                 if (await connectToServer) {
@@ -657,6 +662,6 @@ if (demoq3pak0) {
     }
 }
 if (!demoq3pak0) throw new Error('demoq3/pak0.pk3 not found');
-gotDemoq3pak0(demoq3pak0);
+gotPk3Files([['demoq3/pak0.pk3', Promise.resolve(demoq3pak0)]]);
 
 </script>

--- a/code/web/index.html
+++ b/code/web/index.html
@@ -360,8 +360,20 @@ if (!username || !model) {
     localStorage.setItem('model', model);
 }
 
+const query = new URLSearchParams(window.location.search);
+let server = query.get('server');
+if (query.has('multiplayer')) {
+    if (!server) server = username;
+    let newUrl = new URL(window.location);
+    newUrl.searchParams.delete('multiplayer');
+    newUrl.searchParams.set('server', server);
+    history.replaceState(null, '', newUrl);
+}
+const isFullGame = query.get('full-game') != null ? true : false;
+const basegame = isFullGame ? 'baseq3' : 'demoq3'
+
 let generatedArguments = `
-    +set fs_game demoq3
+    +set fs_game ${basegame}
 `;
 
 let botSkill = 2;
@@ -375,16 +387,6 @@ if (window.matchMedia('(pointer: coarse)').matches) {
     generatedArguments += `
         +set cl_autoAttack 0
     `;
-}
-
-const query = new URLSearchParams(window.location.search);
-let server = query.get('server');
-if (query.has('multiplayer')) {
-    if (!server) server = username;
-    let newUrl = new URL(window.location);
-    newUrl.searchParams.delete('multiplayer');
-    newUrl.searchParams.set('server', server);
-    history.replaceState(null, '', newUrl);
 }
 
 let multiplayer = !!server;
@@ -477,7 +479,9 @@ import(`${buildPath}/ioquake3_opengl2.wasm32.js`).then(async (ioquake3)=>{
             });
             await idbfsReady;
             try {
-                if(!module.FS.analyzePath('/home/web_user/.q3a/demoq3/q3config.cfg').exists) {
+                // TODO maybe preserve the config when switching
+                // between demo and full game?
+                if(!module.FS.analyzePath(`/home/web_user/.q3a/${basegame}/q3config.cfg`).exists) {
                     module.arguments.push(...`
                         +set model "${model}"
                         +set headmodel "${model}"
@@ -485,7 +489,7 @@ import(`${buildPath}/ioquake3_opengl2.wasm32.js`).then(async (ioquake3)=>{
                         `.trim().split(/\s+/));
                 } else {
                     // Read the existing q3config.cfg and update the name and model in case the user changed them.
-                    const q3config = module.FS.readFile('/home/web_user/.q3a/demoq3/q3config.cfg', { encoding: 'utf8' });
+                    const q3config = module.FS.readFile(`/home/web_user/.q3a/${basegame}/q3config.cfg`, { encoding: 'utf8' });
                     const lines = q3config.split('\n');
                     for (let i = 0; i < lines.length; i++) {
                         if (lines[i].startsWith('seta name')) {
@@ -504,12 +508,12 @@ import(`${buildPath}/ioquake3_opengl2.wasm32.js`).then(async (ioquake3)=>{
                 });
             };
             saveFiles();
-            module.FS.mkdirTree('/demoq3');
+            module.FS.mkdirTree(`/${basegame}`);
             const pk3Files = await pk3FilesPromise;
             await Promise.all(pk3Files.map(async ([filePath, file]) => {
                 module.FS.writeFile(filePath, await file);
             }));
-            module.FS.writeFile('/demoq3/ztm-flexible-hud.pk3', await ztmFlexibleHud);
+            module.FS.writeFile(`/${basegame}/ztm-flexible-hud.pk3`, await ztmFlexibleHud);
             if (multiplayer) {
                 if (await connectToServer) {
                     module.arguments.push(...`
@@ -533,7 +537,7 @@ import(`${buildPath}/ioquake3_opengl2.wasm32.js`).then(async (ioquake3)=>{
                     +addbot stripe ${botSkill}
                 `.trim().split(/\s+/));
             }
-            module.FS.writeFile('/demoq3/autoexec.cfg', `
+            module.FS.writeFile(`/${basegame}/autoexec.cfg`, `
                 set in_joystick 1
                 set in_joystickUseAnalog 1
                 set j_forward "0.005"
@@ -614,54 +618,89 @@ import(`${buildPath}/ioquake3_opengl2.wasm32.js`).then(async (ioquake3)=>{
     }
 });
 
-// demoq3/pak0.pk3 is original Quake 3 demo assets. Fetch them from a tarfile in a gz file in a shell script in a zip file at the Internet Archive.
-// First check to see if we have it in the cache
 const cache = await caches.open('thelongestyard');
-const cacheResponse = await cache.match('/demoq3/pak0.pk3');
-let demoq3pak0 = await cacheResponse?.arrayBuffer();
-if (demoq3pak0) {
-    demoq3pak0 = new Uint8Array(demoq3pak0);
-    done.style.transform = 'scaleX(1)';
-} else {
-    const demoSize = 49289300;
-    let sh = await fetch('https://archive.org/download/tucows_286139_Quake_III_Arena/linuxq3ademo-1.11-6.x86.gz.zip/linuxq3ademo-1.11-6.x86.gz.sh').then(r => r.body);
-    // Skip the first 0x155C bytes of the shell script to get the gz file. Ugh, the streams API is terrible.
-    // Also update the progress bar.
-    let downloaded = 0;
-    let gz = sh.pipeThrough(new TransformStream({
-        transform(chunk, controller) {
-            const skip = 0x155C;
-            if (downloaded >= skip) {
-                downloaded += chunk.byteLength;
+if (!isFullGame) {
+    // demoq3/pak0.pk3 is original Quake 3 demo assets. Fetch them from a tarfile in a gz file in a shell script in a zip file at the Internet Archive.
+    // First check to see if we have it in the cache
+    const cacheResponse = await cache.match('/demoq3/pak0.pk3');
+    let demoq3pak0 = await cacheResponse?.arrayBuffer();
+    if (demoq3pak0) {
+        demoq3pak0 = new Uint8Array(demoq3pak0);
+        done.style.transform = 'scaleX(1)';
+    } else {
+        const demoSize = 49289300;
+        let sh = await fetch('https://archive.org/download/tucows_286139_Quake_III_Arena/linuxq3ademo-1.11-6.x86.gz.zip/linuxq3ademo-1.11-6.x86.gz.sh').then(r => r.body);
+        // Skip the first 0x155C bytes of the shell script to get the gz file. Ugh, the streams API is terrible.
+        // Also update the progress bar.
+        let downloaded = 0;
+        let gz = sh.pipeThrough(new TransformStream({
+            transform(chunk, controller) {
+                const skip = 0x155C;
+                if (downloaded >= skip) {
+                    downloaded += chunk.byteLength;
+                    done.style.transform = `scaleX(${downloaded / demoSize * .6 + .2})`;
+                    controller.enqueue(chunk);
+                    return;
+                }
+                const chunkStart = downloaded;
+                const chunkEnd = downloaded + chunk.byteLength;
+                downloaded = chunkEnd;
+                if (chunkEnd < skip) return;
+                controller.enqueue(chunk.subarray(skip - chunkStart));
                 done.style.transform = `scaleX(${downloaded / demoSize * .6 + .2})`;
-                controller.enqueue(chunk);
-                return;
+                if (downloaded === demoSize) {
+                    done.style.transform = 'scaleX(1)';
+                }
             }
-            const chunkStart = downloaded;
-            const chunkEnd = downloaded + chunk.byteLength;
-            downloaded = chunkEnd;
-            if (chunkEnd < skip) return;
-            controller.enqueue(chunk.subarray(skip - chunkStart));
-            done.style.transform = `scaleX(${downloaded / demoSize * .6 + .2})`;
-            if (downloaded === demoSize) {
-                done.style.transform = 'scaleX(1)';
+        }));
+        let tar = new Uint8Array(await new Response(gz.pipeThrough(new DecompressionStream('gzip'))).arrayBuffer());
+        // the tar format is structured in 512 byte blocks. Read the blocks and find the pak0.pk3 file
+        for (let offset = 0; offset < tar.byteLength;) {
+            let name = String.fromCharCode.apply(null, tar.subarray(offset, offset + 100)).replace(/\0/g, '').trim();
+            let size = parseInt(String.fromCharCode.apply(null, tar.subarray(offset + 124, offset + 136)).replace(/\0/g, '').trim(), 8);
+            if (name === 'demoq3/pak0.pk3') {
+                demoq3pak0 = tar.subarray(offset + 512, offset + 512 + size);
+                cache.put('/demoq3/pak0.pk3', new Response(demoq3pak0, { headers: { 'Content-Type': 'application/octet-stream' } }));
+                break;
             }
+            offset += 512 + Math.ceil(size / 512) * 512;
         }
-    }));
-    let tar = new Uint8Array(await new Response(gz.pipeThrough(new DecompressionStream('gzip'))).arrayBuffer());
-    // the tar format is structured in 512 byte blocks. Read the blocks and find the pak0.pk3 file
-    for (let offset = 0; offset < tar.byteLength;) {
-        let name = String.fromCharCode.apply(null, tar.subarray(offset, offset + 100)).replace(/\0/g, '').trim();
-        let size = parseInt(String.fromCharCode.apply(null, tar.subarray(offset + 124, offset + 136)).replace(/\0/g, '').trim(), 8);
-        if (name === 'demoq3/pak0.pk3') {
-            demoq3pak0 = tar.subarray(offset + 512, offset + 512 + size);
-            cache.put('/demoq3/pak0.pk3', new Response(demoq3pak0, { headers: { 'Content-Type': 'application/octet-stream' } }));
-            break;
-        }
-        offset += 512 + Math.ceil(size / 512) * 512;
+    }
+    if (!demoq3pak0) throw new Error('demoq3/pak0.pk3 not found');
+    gotPk3Files([['demoq3/pak0.pk3', Promise.resolve(demoq3pak0)]]);
+} else {
+    const responses = await Promise.all(
+        [
+            '/baseq3/pak0.pk3',
+            '/baseq3/pak1.pk3',
+            '/baseq3/pak2.pk3',
+            '/baseq3/pak3.pk3',
+            '/baseq3/pak4.pk3',
+            '/baseq3/pak5.pk3',
+            '/baseq3/pak6.pk3',
+            '/baseq3/pak7.pk3',
+            '/baseq3/pak8.pk3',
+        ].map(async filePath => [filePath, await cache.match(filePath)])
+    );
+    if (responses.some(([filePath, response]) => response == undefined)) {
+        // Preserve query parameters, such as `server`,
+        // so that that page knows where to return to.
+        const nextUrl = new URL(location.href);
+        nextUrl.pathname = './upload-full-version.html';
+        nextUrl.hash = 'go-back-on-success';
+        location.assign(nextUrl);
+    } else {
+        gotPk3Files(
+            responses.map(([filePath, response]) => [
+                filePath,
+                response.arrayBuffer().then(buf => new Uint8Array(buf))
+            ])
+        );
+
+        // TODO proper progress bar: loading the files into the Emscripten FS
+        // also takes time.
+        done.style.transform = 'scaleX(1)';
     }
 }
-if (!demoq3pak0) throw new Error('demoq3/pak0.pk3 not found');
-gotPk3Files([['demoq3/pak0.pk3', Promise.resolve(demoq3pak0)]]);
 
 </script>

--- a/code/web/index.html
+++ b/code/web/index.html
@@ -527,6 +527,14 @@ import(`${buildPath}/ioquake3_opengl2.wasm32.js`).then(async (ioquake3)=>{
             await Promise.all(pk3Files.map(async ([filePath, file]) => {
                 module.FS.writeFile(filePath, await file);
             }));
+
+            // Free RAM, don't keep duplicate `ArrayBuffer`s.
+            // For some reason `pk3FilesPromise = undefined` is not enough,
+            // according to developer tools,
+            // so let's empty the array. We won't need it anymore.
+            pk3Files.fill(undefined)
+            pk3FilesPromise = undefined;
+
             module.FS.writeFile(`/${basegame}/ztm-flexible-hud.pk3`, await ztmFlexibleHud);
             if (multiplayer) {
                 if (await connectToServer) {

--- a/code/web/upload-full-version.html
+++ b/code/web/upload-full-version.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark light">
+    <title>Upload full version - Quake III Arena Demo</title>
+</head>
+
+<body>
+    <a href="/">Home</a>
+    <br>
+    <br>
+
+    <!-- TODO perhaps the message text can be tailored
+    for when the user gets to this page by trying to join someone else's game,
+    and for when they click "unlock all maps" themselves. -->
+    <p>
+        Purchase the full Quake III Arena to unlock all maps and other content.
+        You can buy the game
+        <a href="http://store.steampowered.com/app/2200/">on Steam</a>
+        or
+        <a href="https://www.gog.com/game/quake_iii_arena">on GOG</a>.
+    </p>
+    <p>
+        In order to play the full game together,
+        all players have to own the full game.
+        <!-- I tried connecting the two together, and was unable to. -->
+    </p>
+    <p>
+        After downloading the game, locate the game directory,
+        and upload the pak0.pk3 - pak8.pk3 files
+        from the "baseq3" directory,
+        using the file picker below.
+    </p>
+    <p>
+        To find the game directory on Steam,
+        find the game in your Steam library,
+        right click it, then, under the "Manage" submenu,
+        click "Browse local files".
+    </p>
+    <p>
+        Don't worry: even after upgrading to the full game,
+        you will still be able to play the demo version with anyone.
+    </p>
+    <p>
+        For more info, see
+        <a href="https://ioquake3.org/help/players-guide">https://ioquake3.org/help/players-guide</a>.
+    </p>
+
+    <form id="gameFilesForm">
+        <label>
+            pak0.pk3 - pak8.pk3 files
+            <br>
+            <input id="gameFilesInput" type="file" accept=".pk3" multiple required />
+        </label>
+        <output>
+            <progress style="display: none" id="uploadProgress" min="0" max="33"></progress>
+            <p id="uploadError" style="display: none">Failed to upload</p>
+        </output>
+    </form>
+
+    <script type="module">
+        // @ts-check
+
+        let goBackOnSuccess = false;
+        if (location.hash === '#go-back-on-success') {
+            goBackOnSuccess = true;
+            // Remove it immediately
+            // so that people don't share the URL like this.
+            location.hash = '';
+        }
+
+        /** @type {HTMLInputElement} */
+        const input = document.getElementById('gameFilesInput');
+        /** @type {HTMLFormElement} */
+        const form = document.getElementById('gameFilesForm');
+        input.onchange = async (event) => {
+            input.setCustomValidity('');
+
+            if (input.files == null || input.files.length === 0) {
+                return;
+            }
+
+            const expectedFileNames = [
+                'pak0.pk3',
+                'pak1.pk3',
+                'pak2.pk3',
+                'pak3.pk3',
+                'pak4.pk3',
+                'pak5.pk3',
+                'pak6.pk3',
+                'pak7.pk3',
+                'pak8.pk3',
+            ]
+
+            let missingFiles = [...expectedFileNames];
+            // const extraneousFiles = [];
+            for (const actual of input.files) {
+                if (expectedFileNames.includes(actual.name)) {
+                    missingFiles = missingFiles.filter(name => name !== actual.name)
+                } else {
+                    // extraneousFiles.push(actual.name);
+                    //
+                    // Let's not prevent users from uploading extra `pk3` files.
+                }
+            }
+
+            /** @type {File | undefined} */
+            const pak0File = [...input.files].find(f => f.name === 'pak0.pk3')
+            if (pak0File != null && pak0File.size < 200_000_000) {
+                input.setCustomValidity(
+                    `The size of the pak0.pk3 file is not the expected 457 MB. Are you sure this is a full game file and not a demo file?`
+                );
+                form.reportValidity();
+                return;
+            }
+
+            if (missingFiles.length > 0) {
+                input.setCustomValidity(
+                    `Please select all files, including ${missingFiles.join(', ')}`
+                );
+                form.reportValidity();
+                return;
+            }
+
+            const cache = await caches.open('thelongestyard');
+            /** @type {File[]} */
+            const filesArr = [...input.files];
+            input.disabled = true;
+
+            /** @type {HTMLProgressElement} */
+            const progress = document.getElementById('uploadProgress');
+            progress.style.display = '';
+            const uploadStartedAt = Date.now()
+            const intervalId = setInterval(() => {
+                const secondsPassed = (Date.now() - uploadStartedAt) / 1000;
+                progress.value = secondsPassed;
+
+                // We expect to take this around 10-30 seconds.
+                // TODO better estimation somehow?
+                if (secondsPassed > 30) {
+                    clearInterval(intervalId);
+                }
+            }, 100);
+
+            try {
+                await Promise.all(filesArr.map(async file => {
+                    await cache.put(`/baseq3/${file.name}`, new Response(file))
+                }));
+            } catch (error) {
+                /** @type {HTMLElement} */
+                const errorEl = document.getElementById('uploadError');
+                errorEl.style.display = '';
+                errorEl.innerText += ' ' + error;
+                progress.style.display = 'none';
+                return
+            } finally {
+                clearInterval(intervalId);
+            }
+
+            console.log('Full game uploaded!')
+            progress.value = progress.max;
+
+            if (goBackOnSuccess) {
+                history.back();
+            } else {
+                // Modify path, but preseve query string.
+                const nextUrl = new URL(location.href);
+                nextUrl.pathname = './index.html'
+                location.assign(nextUrl);
+            }
+        }
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
This is not discoverable by navigating the main page,
because this not really in the spirit
of the thelongestyard.link project.

One can add `?full-game` query parameter to the URL (such as https://thelongestyard.link/q3a-demo/?multiplayer&full-game),
and then we'll ask the user to upload pak0-pak8.pk3 files.

Apart from this hidden feature, the behavior of the project is not affected by this MR.

For easier review, enable "Hide whitespace".