### PR TITLE
refactor: move autoattack from cmd to userinfo

### DIFF
--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1171,6 +1171,7 @@ extern	vmCvar_t		cg_noVoiceText;
 #endif
 extern  vmCvar_t		cg_scorePlum;
 extern	vmCvar_t		cg_smoothClients;
+extern	vmCvar_t 		cg_autoAttack;
 extern	vmCvar_t		pmove_fixed;
 extern	vmCvar_t		pmove_msec;
 //extern	vmCvar_t		cg_pmove_fixed;

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -173,6 +173,7 @@ vmCvar_t	cg_noVoiceText;
 vmCvar_t	cg_hudFiles;
 vmCvar_t 	cg_scorePlum;
 vmCvar_t 	cg_smoothClients;
+vmCvar_t 	cg_autoAttack;
 vmCvar_t	pmove_fixed;
 //vmCvar_t	cg_pmove_fixed;
 vmCvar_t	pmove_msec;
@@ -323,6 +324,7 @@ static cvarTable_t cvarTable[] = {
 	{ &cg_timescale, "timescale", "1", 0},
 	{ &cg_scorePlum, "cg_scorePlums", "1", CVAR_USERINFO | CVAR_ARCHIVE},
 	{ &cg_smoothClients, "cg_smoothClients", "0", CVAR_USERINFO | CVAR_ARCHIVE},
+	{ &cg_autoAttack, "cg_autoAttack", "0", CVAR_USERINFO },
 	{ &cg_cameraMode, "com_cameraMode", "0", CVAR_CHEAT},
 
 	{ &pmove_fixed, "pmove_fixed", "0", CVAR_SYSTEMINFO},

--- a/code/cgame/cg_predict.c
+++ b/code/cgame/cg_predict.c
@@ -496,6 +496,7 @@ void CG_PredictPlayerState( void ) {
 		trap_Cvar_Update(&pmove_msec);
 	}
 
+	cg_pmove.autoAttack = cg_autoAttack.integer;
 	cg_pmove.pmove_fixed = pmove_fixed.integer;// | cg_pmove_fixed.integer;
 	cg_pmove.pmove_msec = pmove_msec.integer;
 

--- a/code/client/cl_input.c
+++ b/code/client/cl_input.c
@@ -546,11 +546,6 @@ void CL_CmdButtons( usercmd_t *cmd ) {
 	if ( anykeydown && Key_GetCatcher( ) == 0 ) {
 		cmd->buttons |= BUTTON_ANY;
 	}
-
-	// TODO: actually detect touchscreen controls and enable this only if they are being used currently, instead of with a cvar
-	if ( cl_autoAttack->integer ) {
-		cmd->buttons |= BUTTON_AUTO_ATTACK;
-	}
 }
 
 

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -120,8 +120,6 @@ cvar_t	*cl_guidServerUniq;
 
 cvar_t	*cl_consoleKeys;
 
-cvar_t	*cl_autoAttack;
-
 cvar_t	*cl_rate;
 
 clientActive_t		cl;
@@ -3618,8 +3616,6 @@ void CL_Init( void ) {
 
 	// ~ and `, as keys and characters
 	cl_consoleKeys = Cvar_Get( "cl_consoleKeys", "~ ` 0x7e 0x60", CVAR_ARCHIVE);
-
-	cl_autoAttack = Cvar_Get( "cl_autoAttack", "0", CVAR_INIT);
 
 	// userinfo
 	Cvar_Get ("name", "UnnamedPlayer", CVAR_USERINFO | CVAR_ARCHIVE );

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -426,8 +426,6 @@ extern	cvar_t	*cl_autoRecordDemo;
 
 extern	cvar_t	*cl_consoleKeys;
 
-extern	cvar_t	*cl_autoAttack;
-
 #ifdef USE_MUMBLE
 extern	cvar_t	*cl_useMumble;
 extern	cvar_t	*cl_mumbleScale;

--- a/code/game/bg_pmove.c
+++ b/code/game/bg_pmove.c
@@ -1925,7 +1925,7 @@ void PmoveSingle (pmove_t *pmove) {
 	// We trace a bunch of rays around the crosshair so that this isn't just a perfect aimbot.
 	// We start shooting when there's something roughly in the default crosshair circle.
 	// We add a small delay so that the user needs to have some aiming skill to keep opponents in their crosshairs for longer than one frame.
-	if ( pmove->cmd.buttons & BUTTON_AUTO_ATTACK ) {
+	if ( pmove->autoAttack ) {
 		// TODO: different firing patterns for different weapons? e.g. rocket launcher activates if shooting below target's feet
 		// TODO: lead moving targets?
 		memcpy(muzzle, pm->ps->origin, sizeof(vec3_t));

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -163,6 +163,7 @@ typedef struct {
 
 	// command (in)
 	usercmd_t	cmd;
+	qboolean	autoAttack;
 	int			tracemask;			// collide against these types of surfaces
 	int			debugLevel;			// if set, diagnostic output will be printed
 	qboolean	noFootsteps;		// if the game is setup for no footsteps by the server

--- a/code/game/g_active.c
+++ b/code/game/g_active.c
@@ -918,6 +918,7 @@ void ClientThink_real( gentity_t *ent ) {
 	pm.debugLevel = g_debugMove.integer;
 	pm.noFootsteps = ( g_dmflags.integer & DF_NO_FOOTSTEPS ) > 0;
 
+	pm.autoAttack = client->pers.autoAttack;
 	pm.pmove_fixed = pmove_fixed.integer | client->pers.pmoveFixed;
 	pm.pmove_msec = pmove_msec.integer;
 

--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -745,6 +745,8 @@ void ClientUserinfoChanged( int clientNum ) {
 		}
 	}
 
+	client->pers.autoAttack = atoi( Info_ValueForKey( userinfo, "cg_autoAttack" ) );
+
 	if ( client->pers.connected == CON_CONNECTED ) {
 		if ( strcmp( oldname, client->pers.netname ) ) {
 			trap_SendServerCommand( -1, va("print \"%s" S_COLOR_WHITE " renamed to %s\n\"", oldname, 

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -235,6 +235,7 @@ typedef struct {
 typedef struct {
 	clientConnected_t	connected;	
 	usercmd_t	cmd;				// we would lose angles if not persistant
+	qboolean	autoAttack;			// whether the client has cg_autoAttack enabled
 	qboolean	localClient;		// true if "ip" info key is "localhost"
 	qboolean	initialSpawn;		// the first spawn should be at a cool location
 	qboolean	predictItemPickup;	// based on cg_predictItems userinfo

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -1248,8 +1248,6 @@ typedef struct playerState_s {
 
 #define	BUTTON_ANY			2048			// any key whatsoever
 
-#define BUTTON_AUTO_ATTACK	4096 		// automatic shooting for touchscreen controls
-
 #define	MOVE_RUN			120			// if forwardmove or rightmove are >= MOVE_RUN,
 										// then BUTTON_WALKING should be set
 

--- a/code/web/index.html
+++ b/code/web/index.html
@@ -366,12 +366,12 @@ let botSkill = 2;
 
 if (window.matchMedia('(pointer: coarse)').matches) {
     generatedArguments += `
-        +set cl_autoAttack 1
+        +set cg_autoAttack 1
         +set g_forcerespawn 2
     `;
 } else {
     generatedArguments += `
-        +set cl_autoAttack 0
+        +set cg_autoAttack 0
     `;
 }
 


### PR DESCRIPTION
This should improve mod compatibility
because userinfo is a less fragile thing,
adding stuff to it shouldn't break other things.

The autoattack feature has been added in
- 6a8ae94d4f7eb04fe53a4c53ef7d4f7fec854c58
- 99b2c54ee9a1dc16986d995febd888136218957e

I have checked that this works.

TODO:
- [ ] Determine if the rename from `cl_autoAttack` to `cg_autoAttack` makes sense. Looking at other vars that have `CVAR_USERINFO`, this seems fine?